### PR TITLE
refactor: reference local leaflet assets

### DIFF
--- a/RestaurantMapApp/Resources/Raw/leaflet/leaflet.css
+++ b/RestaurantMapApp/Resources/Raw/leaflet/leaflet.css
@@ -1,0 +1,1 @@
+/* Placeholder for Leaflet CSS. Actual file should be downloaded separately due to network restrictions. */

--- a/RestaurantMapApp/Resources/Raw/leaflet/leaflet.js
+++ b/RestaurantMapApp/Resources/Raw/leaflet/leaflet.js
@@ -1,0 +1,1 @@
+// Placeholder for Leaflet JS. Actual file should be downloaded separately due to network restrictions.

--- a/RestaurantMapApp/Resources/Raw/map.html
+++ b/RestaurantMapApp/Resources/Raw/map.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="leaflet/leaflet.css" />
     <style>
         html, body, #map {
             height: 100%;
@@ -63,7 +63,7 @@
 </head>
 <body>
     <div id="map"></div>
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="leaflet/leaflet.js"></script>
     <script>
         // İstanbul merkez
         const map = L.map('map').setView([41.0082, 28.9784], 11);


### PR DESCRIPTION
## Summary
- use local Leaflet assets in map.html
- add placeholder Leaflet CSS/JS files

## Testing
- `dotnet build RestaurantMapApp.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc20f36008330aefb5864e3007484